### PR TITLE
[FEAT] 초기화 API 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// webflux for external api
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/org/prography/pingpong/domain/room/repository/RoomRepository.java
+++ b/src/main/java/org/prography/pingpong/domain/room/repository/RoomRepository.java
@@ -1,0 +1,7 @@
+package org.prography.pingpong.domain.room.repository;
+
+import org.prography.pingpong.domain.room.entity.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomRepository extends JpaRepository<Room, Integer> {
+}

--- a/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
+++ b/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
@@ -1,0 +1,20 @@
+package org.prography.pingpong.domain.room.service;
+
+import lombok.RequiredArgsConstructor;
+import org.prography.pingpong.domain.room.repository.RoomRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RoomService {
+
+    private final RoomRepository roomRepository;
+
+    @Transactional
+    public void deleteAll() {
+        roomRepository.deleteAll();
+    }
+
+}

--- a/src/main/java/org/prography/pingpong/domain/user/entity/User.java
+++ b/src/main/java/org/prography/pingpong/domain/user/entity/User.java
@@ -19,6 +19,7 @@ public class User {
     @Column(name = "userId")
     private Integer id;
 
+    @OrderColumn
     private Integer fakerId;
 
     private String name;

--- a/src/main/java/org/prography/pingpong/domain/user/entity/enums/UserStatus.java
+++ b/src/main/java/org/prography/pingpong/domain/user/entity/enums/UserStatus.java
@@ -13,4 +13,10 @@ public enum UserStatus {
     UserStatus(String description) {
         this.description = description;
     }
+
+    public static UserStatus fromFakerId(Integer fakerId) {
+        if(fakerId <= 30) return ACTIVE;                    // 응답 값의 id(fakerId) 값이 30 이하의 회원은 활성(ACTIVE) 상태
+        if(31 <= fakerId && fakerId <= 60) return WAIT;     // 응답 값의 id(fakerId) 값이 31 이상, 60 이하의 회원은 대기(WAIT) 상태
+        return NON_ACTIVE;                // 응답 값의 id(fakerId) 값이 61 이상인 회원은 비활성(NON_ACTIVE) 상태
+    }
 }

--- a/src/main/java/org/prography/pingpong/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/prography/pingpong/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package org.prography.pingpong.domain.user.repository;
+
+import org.prography.pingpong.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+}

--- a/src/main/java/org/prography/pingpong/domain/user/service/UserService.java
+++ b/src/main/java/org/prography/pingpong/domain/user/service/UserService.java
@@ -1,0 +1,22 @@
+package org.prography.pingpong.domain.user.service;
+
+
+
+import lombok.RequiredArgsConstructor;
+import org.prography.pingpong.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void deleteAll() {
+        userRepository.deleteAll();
+    }
+
+}

--- a/src/main/java/org/prography/pingpong/global/init/controller/InitController.java
+++ b/src/main/java/org/prography/pingpong/global/init/controller/InitController.java
@@ -1,19 +1,30 @@
 package org.prography.pingpong.global.init.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.prography.pingpong.domain.room.service.RoomService;
+import org.prography.pingpong.domain.user.entity.User;
+import org.prography.pingpong.domain.user.service.UserService;
 import org.prography.pingpong.global.common.response.ApiResponse;
 import org.prography.pingpong.global.init.dto.InitReqDto;
+import org.prography.pingpong.global.init.service.InitService;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/init")
+@RequiredArgsConstructor
 public class InitController {
 
+    private final InitService initService;
+
     @PostMapping
-    public ApiResponse init(@RequestBody @Validated InitReqDto initReqDto) {
+    public ApiResponse init(@RequestBody @Validated InitReqDto initReqDto) throws Exception {
+        initService.init(initReqDto.seed(), initReqDto.quantity());
         return ApiResponse.success();
     }
 

--- a/src/main/java/org/prography/pingpong/global/init/controller/InitController.java
+++ b/src/main/java/org/prography/pingpong/global/init/controller/InitController.java
@@ -24,8 +24,8 @@ public class InitController {
 
     @PostMapping
     public ApiResponse init(@RequestBody @Validated InitReqDto initReqDto) throws Exception {
-        initService.init(initReqDto.seed(), initReqDto.quantity());
-        return ApiResponse.success();
+        List<User> init = initService.init(initReqDto.seed(), initReqDto.quantity());
+        return ApiResponse.success(init);
     }
 
 }

--- a/src/main/java/org/prography/pingpong/global/init/controller/InitController.java
+++ b/src/main/java/org/prography/pingpong/global/init/controller/InitController.java
@@ -1,9 +1,6 @@
 package org.prography.pingpong.global.init.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.prography.pingpong.domain.room.service.RoomService;
-import org.prography.pingpong.domain.user.entity.User;
-import org.prography.pingpong.domain.user.service.UserService;
 import org.prography.pingpong.global.common.response.ApiResponse;
 import org.prography.pingpong.global.init.dto.InitReqDto;
 import org.prography.pingpong.global.init.service.InitService;
@@ -24,8 +21,8 @@ public class InitController {
 
     @PostMapping
     public ApiResponse init(@RequestBody @Validated InitReqDto initReqDto) throws Exception {
-        List<User> init = initService.init(initReqDto.seed(), initReqDto.quantity());
-        return ApiResponse.success(init);
+        initService.init(initReqDto.seed(), initReqDto.quantity());
+        return ApiResponse.success();
     }
 
 }

--- a/src/main/java/org/prography/pingpong/global/init/dto/FakerApiResDto.java
+++ b/src/main/java/org/prography/pingpong/global/init/dto/FakerApiResDto.java
@@ -1,0 +1,33 @@
+package org.prography.pingpong.global.init.dto;
+
+import org.prography.pingpong.domain.user.entity.User;
+import org.prography.pingpong.domain.user.entity.enums.UserStatus;
+
+import java.util.List;
+
+public record FakerApiResDto(
+        String status,
+        Integer code,
+        String locale,
+        String seed,
+        Integer total,
+        List<FakerUserDto> data
+) {
+    public record FakerUserDto(
+            Integer id,
+            String uuid,
+            String firstname,
+            String lastname,
+            String username,
+            String password,
+            String email,
+            String ip,
+            String macAddress,
+            String website,
+            String image
+    ) {
+        public User createUser() {
+            return User.create(id, username, email, UserStatus.fromFakerId(id));
+        }
+    }
+}

--- a/src/main/java/org/prography/pingpong/global/init/service/InitService.java
+++ b/src/main/java/org/prography/pingpong/global/init/service/InitService.java
@@ -21,7 +21,7 @@ public class InitService {
     private final RoomRepository roomRepository;
 
     @Transactional
-    public void init(Integer seed, Integer quantity) throws Exception {
+    public List<User> init(Integer seed, Integer quantity) throws Exception {
 
         /*
          * 모든 회원 정보 및 방 정보를 삭제
@@ -57,7 +57,7 @@ public class InitService {
                 .filter(Objects::nonNull)
                 .toList();
 
-        userRepository.saveAllAndFlush(users);
+        return userRepository.saveAllAndFlush(users);
 
     }
 

--- a/src/main/java/org/prography/pingpong/global/init/service/InitService.java
+++ b/src/main/java/org/prography/pingpong/global/init/service/InitService.java
@@ -1,0 +1,65 @@
+package org.prography.pingpong.global.init.service;
+
+import lombok.RequiredArgsConstructor;
+import org.prography.pingpong.domain.room.repository.RoomRepository;
+import org.prography.pingpong.domain.user.entity.User;
+import org.prography.pingpong.domain.user.repository.UserRepository;
+import org.prography.pingpong.global.init.dto.FakerApiResDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class InitService {
+
+    private final UserRepository userRepository;
+    private final RoomRepository roomRepository;
+
+    @Transactional
+    public void init(Integer seed, Integer quantity) throws Exception {
+
+        /*
+         * 모든 회원 정보 및 방 정보를 삭제
+         */
+        userRepository.deleteAllInBatch();
+        roomRepository.deleteAllInBatch();
+
+        /*
+         * 외부 API 호출
+         */
+        FakerApiResDto fakerApiResDto = WebClient.builder().baseUrl("https://fakerapi.it").build()
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/api/v1/users")
+                        .queryParam("_seed", seed)
+                        .queryParam("_quantity", quantity)
+                        .queryParam("_locale", "ko_KR")
+                        .build()
+                )
+                .retrieve()
+                .bodyToMono(FakerApiResDto.class)
+                .block();
+
+        /*
+         * 회원 정보 저장
+         */
+        if(fakerApiResDto.code() != 200) throw new IllegalStateException("service");    // API 호출 실패
+
+        List<User> users = Optional.ofNullable(fakerApiResDto.data())
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(FakerApiResDto.FakerUserDto::createUser)
+                .filter(Objects::nonNull)
+                .toList();
+
+        userRepository.saveAllAndFlush(users);
+
+    }
+
+
+}

--- a/src/main/java/org/prography/pingpong/global/init/service/InitService.java
+++ b/src/main/java/org/prography/pingpong/global/init/service/InitService.java
@@ -8,7 +8,6 @@ import org.prography.pingpong.global.init.dto.FakerApiResDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
 import java.util.*;
 
@@ -21,7 +20,7 @@ public class InitService {
     private final RoomRepository roomRepository;
 
     @Transactional
-    public List<User> init(Integer seed, Integer quantity) throws Exception {
+    public void init(Integer seed, Integer quantity) throws Exception {
 
         /*
          * 모든 회원 정보 및 방 정보를 삭제
@@ -57,7 +56,7 @@ public class InitService {
                 .filter(Objects::nonNull)
                 .toList();
 
-        return userRepository.saveAllAndFlush(users);
+        userRepository.saveAllAndFlush(users);
 
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,5 +12,7 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
+        default_batch_fetch_size: 100
+
   jackson:
     default-property-inclusion: non_null  # null 값 필드를 JSON에서 제외


### PR DESCRIPTION
# ✏️ Description

### 초기화 API

- seed와 quantity를 body에 담아서 요청합니다.
- 기존에 있던 모든 회원 정보 및 방 정보를 삭제합니다. **(즉, 모든 table의 모든 데이터를 삭제합니다.)**
- 이후 body로 전달받은 seed와 quantity정보를 통해 아래 API를 호출하여 서비스에 필요한 회원 정보를 저장합니다.
    - https://fakerapi.it/api/v1/users?_seed={seed}&_quantity={quantity}&_locale=ko_KR
- fakerapi의 응답 결과로 내려오는 데이터를 아래 규칙에 따라 세팅합니다.
    - 응답 값의 id필드는 fakerId로 저장합니다.
    - 응답 값의 id(fakerId)를 오름차순으로 정렬하여 데이터를 저장합니다.
    - username 필드는 name으로 저장합니다.
    - email 필드는 그대로 저장합니다.
    - uuid, firstname, lastname, password, ip, macAddress, website, image 필드는 사용하지 않습니다.
    - 회원 상태(status)는 응답 값의 id(fakerId)를 기반하여 아래 규칙에 따라 저장합니다.
        - 응답 값의 id(fakerId) 값이 30 이하의 회원은 활성(ACTIVE) 상태로 세팅합니다.
        - 응답 값의 id(fakerId) 값이 31 이상, 60 이하의 회원은 대기(WAIT) 상태로 세팅합니다.
        - 응답 값의 id(fakerId) 값이 61 이상인 회원은 비활성(NON_ACTIVE) 상태로 세팅합니다.
    - 데이터가 저장되는 시점에 따라 createdAt과 updatedAt을 저장합니다.

## WebClient

외부 API를 호출하기 위한 WebClient를 사용한다.

### build.gradle
```
implementation 'org.springframework.boot:spring-boot-starter-webflux'
```

### InitService
```java
// 외부 API 호출
FakerApiResDto fakerApiResDto = WebClient.builder().baseUrl("https://fakerapi.it").build()
        .get()
        .uri(uriBuilder -> uriBuilder
                .path("/api/v1/users")
                .queryParam("_seed", seed)
                .queryParam("_quantity", quantity)
                .queryParam("_locale", "ko_KR")
                .build()
        )
        .retrieve()
        .bodyToMono(FakerApiResDto.class)
        .block();
```


