### PR TITLE
[FEAT] 유저 전체 조회 API

### DIFF
--- a/src/main/java/org/prography/pingpong/domain/user/controller/UserController.java
+++ b/src/main/java/org/prography/pingpong/domain/user/controller/UserController.java
@@ -1,21 +1,27 @@
 package org.prography.pingpong.domain.user.controller;
 
 
+import lombok.RequiredArgsConstructor;
+import org.prography.pingpong.domain.user.dto.UserListResDto;
+import org.prography.pingpong.domain.user.service.UserService;
 import org.prography.pingpong.global.common.response.ApiResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.awt.print.Pageable;
 
 @RestController
 @RequestMapping("/user")
+@RequiredArgsConstructor
 public class UserController {
 
+    private final UserService userService;
+
     @GetMapping
-    public ApiResponse user(@RequestParam("size") int size, @RequestParam("page") int page) {
-        return ApiResponse.success();
+    public ApiResponse user(@PageableDefault(sort = "id") Pageable pageable) {
+        UserListResDto userListResDto = userService.findAll(pageable);
+        return ApiResponse.success(userListResDto);
     }
 
 }

--- a/src/main/java/org/prography/pingpong/domain/user/dto/UserListResDto.java
+++ b/src/main/java/org/prography/pingpong/domain/user/dto/UserListResDto.java
@@ -1,0 +1,42 @@
+package org.prography.pingpong.domain.user.dto;
+
+import org.prography.pingpong.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record UserListResDto(
+        Integer totalElements,
+        Integer totalPages,
+        List<UserResDto> userList
+) {
+    public record UserResDto(
+            Integer id,
+            Integer fakerId,
+            String name,
+            String email,
+            String status
+    ) {
+        public static UserResDto create(User user) {
+            return new UserResDto(
+                    user.getId(),
+                    user.getFakerId(),
+                    user.getName(),
+                    user.getEmail(),
+                    user.getStatus().name()
+            );
+        }
+    }
+
+    public static UserListResDto create(Page<User> userPage) {
+        List<UserResDto> userList = userPage.getContent().stream()
+                .map(UserResDto::create)
+                .toList();
+
+        return new UserListResDto(
+                (int) userPage.getTotalElements(),
+                userPage.getTotalPages(),
+                userList
+        );
+    }
+}

--- a/src/main/java/org/prography/pingpong/domain/user/service/UserService.java
+++ b/src/main/java/org/prography/pingpong/domain/user/service/UserService.java
@@ -3,7 +3,11 @@ package org.prography.pingpong.domain.user.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.prography.pingpong.domain.user.dto.UserListResDto;
+import org.prography.pingpong.domain.user.entity.User;
 import org.prography.pingpong.domain.user.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +21,12 @@ public class UserService {
     @Transactional
     public void deleteAll() {
         userRepository.deleteAll();
+    }
+
+    public UserListResDto findAll(Pageable pageable) {
+        Page<User> userList = userRepository.findAll(pageable);
+        UserListResDto userListResDto = UserListResDto.create(userList);
+        return userListResDto;
     }
 
 }


### PR DESCRIPTION
# ✏️ Description
### 유저 전체 조회 API
- 페이징 처리를 위한 size, page 값을 RequestParameter로 받습니다.
- 모든 회원 정보를 응답합니다.
  - id 기준 오름차순으로 정렬해서 반환합니다.

> API 명세
```
GET /user?size={size}&page={page}
```
​
> Response
```
{
  "code" : 200,
  "message" : "API 요청이 성공했습니다.",
  "result" : {
		"totalElements" : int,
		"totalPages" : int,
		"userList" : [
			{
				"id" : int,
				"fakerId" : int,
				"name" : string,
				"email" : string,
				"status" : string, // WAIT(대기), ACTIVE(활성), NON_ACTIVE(비활성)
				"createdAt" : string, // yyyy-MM-dd HH:mm:ss 형태로 반환합니다.
				"updatedAt" : string // yyyy-MM-dd HH:mm:ss 형태로 반환합니다.
			}, ...
		]
	}
}
```

## @RequestParam -> Pageable

Controller에서 파라미터로 전달받던 size, page의 값을 @RequestParam에서 Pageable로 변경하였다.

```java
@GetMapping
    public ApiResponse user(@PageableDefault(sort = "id") Pageable pageable) {
        UserListResDto userListResDto = userService.findAll(pageable);
        return ApiResponse.success(userListResDto);
    }
```