### PR TITLE
[FEAT] 방 생성 API

### DIFF
--- a/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
+++ b/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
@@ -1,15 +1,21 @@
 package org.prography.pingpong.domain.room.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.prography.pingpong.domain.room.dto.*;
+import org.prography.pingpong.domain.room.service.RoomService;
 import org.prography.pingpong.global.common.response.ApiResponse;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
 public class RoomController {
+
+    private final RoomService roomService;
 
     @PostMapping("/room")
     public ApiResponse createRoom(@RequestBody @Validated RoomCreateReqDto roomCreateReqDto) {
+        roomService.createRoom(roomCreateReqDto);
         return ApiResponse.success();
     }
 

--- a/src/main/java/org/prography/pingpong/domain/room/dto/RoomCreateReqDto.java
+++ b/src/main/java/org/prography/pingpong/domain/room/dto/RoomCreateReqDto.java
@@ -2,12 +2,20 @@ package org.prography.pingpong.domain.room.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.prography.pingpong.domain.room.entity.Room;
+import org.prography.pingpong.domain.room.entity.enums.RoomStatus;
+import org.prography.pingpong.domain.room.entity.enums.RoomType;
+import org.prography.pingpong.domain.user.entity.User;
 
 public record RoomCreateReqDto(
         @NotNull
         Integer userId,
-        @NotBlank
-        String roomType,
+        @NotNull
+        RoomType roomType,
         @NotBlank
         String title) {
+
+        public Room create(User user) {
+                return Room.create(title, user, roomType, RoomStatus.WAIT);
+        }
 }

--- a/src/main/java/org/prography/pingpong/domain/room/entity/Room.java
+++ b/src/main/java/org/prography/pingpong/domain/room/entity/Room.java
@@ -24,7 +24,7 @@ public class Room {
     private String title;
 
     @OneToOne
-    @JoinColumn(name = "id")
+    @JoinColumn(name = "userId")
     private User host;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/prography/pingpong/domain/room/entity/UserRoom.java
+++ b/src/main/java/org/prography/pingpong/domain/room/entity/UserRoom.java
@@ -15,11 +15,11 @@ public class UserRoom {
 
     @OneToOne
     @JoinColumn(name = "roomId")
-    private Room room_id;
+    private Room room;
 
     @OneToOne
     @JoinColumn(name = "userId")
-    private User user_id;
+    private User user;
 
     @Enumerated(EnumType.STRING)
     private Team team;

--- a/src/main/java/org/prography/pingpong/domain/room/repository/RoomRepository.java
+++ b/src/main/java/org/prography/pingpong/domain/room/repository/RoomRepository.java
@@ -3,5 +3,10 @@ package org.prography.pingpong.domain.room.repository;
 import org.prography.pingpong.domain.room.entity.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RoomRepository extends JpaRepository<Room, Integer> {
+
+    boolean existsByHostId(Integer hostId);
+
 }

--- a/src/main/java/org/prography/pingpong/domain/room/repository/UserRoomRepository.java
+++ b/src/main/java/org/prography/pingpong/domain/room/repository/UserRoomRepository.java
@@ -1,0 +1,12 @@
+package org.prography.pingpong.domain.room.repository;
+
+import org.prography.pingpong.domain.room.entity.UserRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRoomRepository extends JpaRepository<UserRoom, Integer> {
+
+    boolean existsByUserId(Integer userId);
+
+}

--- a/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
+++ b/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
@@ -1,7 +1,14 @@
 package org.prography.pingpong.domain.room.service;
 
 import lombok.RequiredArgsConstructor;
+import org.prography.pingpong.domain.room.dto.RoomCreateReqDto;
+import org.prography.pingpong.domain.room.entity.Room;
 import org.prography.pingpong.domain.room.repository.RoomRepository;
+import org.prography.pingpong.domain.room.repository.UserRoomRepository;
+import org.prography.pingpong.domain.user.entity.User;
+import org.prography.pingpong.domain.user.entity.enums.UserStatus;
+import org.prography.pingpong.domain.user.repository.UserRepository;
+import org.prography.pingpong.global.exception.ApiException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,10 +18,43 @@ import org.springframework.transaction.annotation.Transactional;
 public class RoomService {
 
     private final RoomRepository roomRepository;
+    private final UserRoomRepository userRoomRepository;
+    private final UserRepository userRepository;
+
 
     @Transactional
     public void deleteAll() {
         roomRepository.deleteAll();
+    }
+
+    @Transactional
+    public void createRoom(RoomCreateReqDto roomCreateReqDto) {
+
+        /*
+         * 방을 생성하려고 하는 user(userId)의 상태가 활성(ACTIVE)상태일 때만, 방을 생성
+         */
+        Integer userId = roomCreateReqDto.userId();
+        User findUser = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException("RoomService.createRoom"));
+
+        if(!findUser.getStatus().equals(UserStatus.ACTIVE))
+            throw new ApiException("RoomService.createRoom");
+
+        /*
+         * 방을 생성하려고 하는 user(userId)가 현재 참여한 방이 있다면, 방생성 X
+         */
+        if(roomRepository.existsByHostId(userId))
+            throw new ApiException("RoomService.createRoom");
+
+        if(userRoomRepository.existsByUserId(userId))
+            throw new ApiException("RoomService.createRoom");
+
+        /*
+         * 방은 초기에 대기(WAIT) 상태로 생성
+         */
+        Room room = roomCreateReqDto.create(findUser);
+        roomRepository.save(room);
+
     }
 
 }

--- a/src/main/java/org/prography/pingpong/global/exception/ApiException.java
+++ b/src/main/java/org/prography/pingpong/global/exception/ApiException.java
@@ -1,0 +1,9 @@
+package org.prography.pingpong.global.exception;
+
+public class ApiException extends RuntimeException {
+
+    public ApiException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/org/prography/pingpong/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/prography/pingpong/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package org.prography.pingpong.global.exception;
+
+import org.prography.pingpong.global.common.response.ApiResponse;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ApiResponse handleException(Exception e) {
+        return ApiResponse.error();
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ApiResponse handleIllegalArgumentException(IllegalArgumentException e) {
+        return ApiResponse.error(e.getMessage());
+    }
+
+}

--- a/src/main/java/org/prography/pingpong/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/prography/pingpong/global/exception/GlobalExceptionHandler.java
@@ -12,9 +12,9 @@ public class GlobalExceptionHandler {
         return ApiResponse.error();
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ApiResponse handleIllegalArgumentException(IllegalArgumentException e) {
-        return ApiResponse.error(e.getMessage());
+    @ExceptionHandler(ApiException.class)
+    public ApiResponse handleApiException(ApiException e) {
+        return ApiResponse.fail();
     }
 
 }

--- a/src/main/java/org/prography/pingpong/global/init/service/InitService.java
+++ b/src/main/java/org/prography/pingpong/global/init/service/InitService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.prography.pingpong.domain.room.repository.RoomRepository;
 import org.prography.pingpong.domain.user.entity.User;
 import org.prography.pingpong.domain.user.repository.UserRepository;
+import org.prography.pingpong.global.exception.ApiException;
 import org.prography.pingpong.global.init.dto.FakerApiResDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,7 +48,7 @@ public class InitService {
         /*
          * 회원 정보 저장
          */
-        if(fakerApiResDto.code() != 200) throw new IllegalStateException("service");    // API 호출 실패
+        if(fakerApiResDto.code() != 200) throw new ApiException("InitService.init");    // API 호출 실패
 
         List<User> users = Optional.ofNullable(fakerApiResDto.data())
                 .orElse(Collections.emptyList())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update # TODO change create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
# ✏️ Description

### 방 생성 API

- userId, roomType, title 정보는 body에 담아서 요청합니다.
- 방을 생성하려고 하는 user(userId)의 상태가 활성(ACTIVE)상태일 때만, 방을 생성할 수 있습니다. 만약 활성상태가 아닐때는 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/prography-admin/Spring-197b28e6e3f280f69b43d12da8fc694a#6-4-%EA%B3%B5%ED%86%B5-API-Response-%EC%95%88%EB%82%B4) 참고)
- 방을 생성하려고 하는 user(userId)가 현재 참여한 방이 있다면, 방을 생성할 수 없습니다. 만약 참여하고 있는 방이 있을때는 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/prography-admin/Spring-197b28e6e3f280f69b43d12da8fc694a#6-4-%EA%B3%B5%ED%86%B5-API-Response-%EC%95%88%EB%82%B4) 참고)
- 방은 초기에 대기(WAIT) 상태로 생성됩니다.
- 데이터가 저장되는 시점에 따라 createdAt과 updatedAt을 저장합니다.

> API 명세
```
POST /room
body
{
   "userId" : int,
   "roomType" : String,
   "title" : String
}
```
​
> Response
```
{
  "code" : 200,
  "message" : "API 요청이 성공했습니다."
}
```

## 예외 처리를 위한 @RestControllerAdvice

### ApiException
```java
public class ApiException extends RuntimeException {

    public ApiException(String message) {
        super(message);
    }

}
```

### GlobalExceptionHandler
```java
@RestControllerAdvice
public class GlobalExceptionHandler {

    @ExceptionHandler(Exception.class)
    public ApiResponse handleException(Exception e) {
        return ApiResponse.error();
    }

    @ExceptionHandler(ApiException.class)
    public ApiResponse handleApiException(ApiException e) {
        return ApiResponse.fail();
    }

}
```