### PR TITLE
<faet #17> 방 전체 조회 API

### DIFF
--- a/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
+++ b/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.prography.pingpong.domain.room.dto.*;
 import org.prography.pingpong.domain.room.service.RoomService;
 import org.prography.pingpong.global.common.response.ApiResponse;
+import org.springframework.data.domain.Pageable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,8 +21,9 @@ public class RoomController {
     }
 
     @GetMapping("/room")
-    public ApiResponse room(@RequestParam("size") int size, @RequestParam("page") int page) {
-        return ApiResponse.success();
+    public ApiResponse room(Pageable pageable) {
+        RoomListResDto roomListResDto = roomService.findAll(pageable);
+        return ApiResponse.success(roomListResDto);
     }
 
     @GetMapping("/room/{roomId}")

--- a/src/main/java/org/prography/pingpong/domain/room/dto/RoomListResDto.java
+++ b/src/main/java/org/prography/pingpong/domain/room/dto/RoomListResDto.java
@@ -1,0 +1,43 @@
+package org.prography.pingpong.domain.room.dto;
+
+import org.prography.pingpong.domain.room.entity.Room;
+import org.prography.pingpong.domain.room.entity.enums.RoomType;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record RoomListResDto(
+        Integer totalElements,
+        Integer totalPages,
+        List<RoomResDto> roomList
+) {
+    public record RoomResDto(
+            Integer id,
+            String title,
+            Integer hostId,
+            RoomType roomType,  // SINGLE(단식), DOUBLE(복식)
+            String status     // WAIT(대기), PROGRESS(진행중), FINISH(완료)
+    ) {
+        public static RoomResDto create(Room room) {
+            return new RoomResDto(
+                    room.getId(),
+                    room.getTitle(),
+                    room.getHost().getId(),
+                    room.getRoom_type(),
+                    room.getStatus().name()
+            );
+        }
+    }
+
+    public static RoomListResDto create(Page<Room> roomPage) {
+        List<RoomResDto> roomList = roomPage.getContent().stream()
+                .map(RoomResDto::create)
+                .toList();
+
+        return new RoomListResDto(
+                (int) roomPage.getTotalElements(),
+                roomPage.getTotalPages(),
+                roomList
+        );
+    }
+}

--- a/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
+++ b/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
@@ -2,6 +2,7 @@ package org.prography.pingpong.domain.room.service;
 
 import lombok.RequiredArgsConstructor;
 import org.prography.pingpong.domain.room.dto.RoomCreateReqDto;
+import org.prography.pingpong.domain.room.dto.RoomListResDto;
 import org.prography.pingpong.domain.room.entity.Room;
 import org.prography.pingpong.domain.room.repository.RoomRepository;
 import org.prography.pingpong.domain.room.repository.UserRoomRepository;
@@ -9,6 +10,8 @@ import org.prography.pingpong.domain.user.entity.User;
 import org.prography.pingpong.domain.user.entity.enums.UserStatus;
 import org.prography.pingpong.domain.user.repository.UserRepository;
 import org.prography.pingpong.global.exception.ApiException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,6 +58,12 @@ public class RoomService {
         Room room = roomCreateReqDto.create(findUser);
         roomRepository.save(room);
 
+    }
+
+    public RoomListResDto findAll(Pageable pageable) {
+        Page<Room> roomList = roomRepository.findAll(pageable);
+        RoomListResDto roomListResDto = RoomListResDto.create(roomList);
+        return roomListResDto;
     }
 
 }


### PR DESCRIPTION
# ✏️ Description
- 페이징 처리를 위한 size, page 값을 RequestParameter로 받습니다.
- 모든 방에 대한 데이터를 반환합니다.
    - id 기준 오름차순으로 데이터를 반환합니다.

> API 명세

```
GET /room?size={size}&page={page}
```

> Response

```
{
  "code" : 200,
  "message" : "API 요청이 성공했습니다.",
  "result" : {
		"totalElements" : int,
		"totalPages" : int,
		"roomList" : [
			{
				"id" : int,
				"title" : string,
				"hostId" : int,
				"roomType" : string, // SINGLE(단식), DOUBLE(복식)
				"status" : string, // WAIT(대기), PROGRESS(진행중), FINISH(완료)
			}, ...
		]
	}
}
```
