### PR TITLE
[FEAT] 방 참가 API

### DIFF
--- a/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
+++ b/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
@@ -35,6 +35,7 @@ public class RoomController {
     @PostMapping("/room/attention/{roomId}")
     public ApiResponse attentionRoom(@PathVariable("roomId") int roomId,
                                      @RequestBody @Validated RoomAttentionReqDto roomAttentionReqDto) {
+        roomService.attendRoom(roomId, roomAttentionReqDto);
         return ApiResponse.success();
     }
 

--- a/src/main/java/org/prography/pingpong/domain/room/entity/Room.java
+++ b/src/main/java/org/prography/pingpong/domain/room/entity/Room.java
@@ -23,7 +23,7 @@ public class Room {
 
     private String title;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId")
     private User host;
 

--- a/src/main/java/org/prography/pingpong/domain/room/entity/UserRoom.java
+++ b/src/main/java/org/prography/pingpong/domain/room/entity/UserRoom.java
@@ -13,14 +13,43 @@ public class UserRoom {
     @Column(name="userRoomId")
     private Integer id;
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "roomId")
     private Room room;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId")
     private User user;
 
     @Enumerated(EnumType.STRING)
     private Team team;
+
+    public UserRoom() {
+    }
+
+    protected UserRoom(Room room, User user, Team team) {
+        this.room = room;
+        this.user = user;
+        this.team = team;
+    }
+
+    public static UserRoom create(Room room, User user, Team team) {
+        return new UserRoom(room, user, team);
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Room getRoom() {
+        return room;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public Team getTeam() {
+        return team;
+    }
 }

--- a/src/main/java/org/prography/pingpong/domain/room/repository/UserRoomRepository.java
+++ b/src/main/java/org/prography/pingpong/domain/room/repository/UserRoomRepository.java
@@ -9,4 +9,6 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Integer> {
 
     boolean existsByUserId(Integer userId);
 
+    int countByRoomId(Integer roomId);
+
 }


### PR DESCRIPTION
# ✏️ Description
### 방 참가 API

- 대기(WAIT) 상태인 방에만 참가가 가능합니다. 만약 대기상태가 아닌 방이라면 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)
- 유저(userId)가 활성(ACTIVE) 상태일 때만, 방에 참가할 수 있습니다. 만약 활성상태가 아니라면 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)
- 유저(userId)가 현재 참여한 방이 없을때만, 방에 참가할 수 있습니다. 만약 참여한 방이 있다면 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)
- 참가하고자 하는 방(roomId)의 정원이 미달일 때만, 참가가 가능합니다. 만약 방에 인원이 가득 찼다면 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)
- 존재하지 않는 id에 대한 요청이라면 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)

> API 명세
```
POST /room/attention/{roomId}
body
{
   "userId" : int
}
```

> Response
```json
{
  "code" : 200,
  "message" : "API 요청이 성공했습니다."
}
```

## 1:1 -> 1:N 관계로 변경

기존 UserRoom의 Room 객체와 @OneToOne 관계로 잘못 설정한 것을 @ManyToOne으로 변경

### UserRoom
```java
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "roomId")
    private Room room;
```