### PR TITLE
[FEAT] 게임시작 API

### DIFF
--- a/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
+++ b/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
@@ -49,6 +49,7 @@ public class RoomController {
     @PutMapping("/room/start/{roomId}")
     public ApiResponse startRoom(@PathVariable("roomId") int roomId,
                                  @RequestBody @Validated RoomStartReqDto roomStartReqDto) {
+        roomService.startRoom(roomId, roomStartReqDto);
         return ApiResponse.success();
     }
 

--- a/src/main/java/org/prography/pingpong/domain/room/repository/RoomRepository.java
+++ b/src/main/java/org/prography/pingpong/domain/room/repository/RoomRepository.java
@@ -11,4 +11,5 @@ public interface RoomRepository extends JpaRepository<Room, Integer> {
 
     boolean existsByIdAndHostId(Integer userId, Integer roomId);
 
+    Optional<Room> findByIdAndHostId(int roomId, Integer userId);
 }

--- a/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
+++ b/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
@@ -131,6 +131,29 @@ public class RoomService {
 
     }
 
+    @Transactional
+    public void startRoom(int roomId, RoomStartReqDto roomStartReqDto) {
+        // 호스트인 유저만 게임을 시작 가능
+        Room room = roomRepository.findByIdAndHostId(roomId, roomStartReqDto.userId())
+                .orElseThrow(() -> new ApiException("RoomService.startRoom"));
+
+        // 방 정원이 방의 타입에 맞게 모두 꽉 찬 상태에서만 게임 시작
+        int userCount = userRoomRepository.countByRoomId(roomId);
+        if(room.getType().equals(RoomType.SINGLE) && userCount != 1) throw new ApiException("RoomService.startRoom");
+        if(room.getType().equals(RoomType.DOUBLE) && userCount != 3) throw new ApiException("RoomService.startRoom");
+
+        // 현재 방의 상태가 대기(WAIT) 상태일 때만 시작
+        if(!room.getStatus().equals(RoomStatus.WAIT))
+            throw new ApiException("RoomService.startRoom");
+
+        // 방의 상태를 진행중(PROGRESS) 상태로 변경
+        room.changeStatus(RoomStatus.PROGRESS);
+
+
+
+        // 대기(WAIT) 상태인 방만 ��임을 시작 가능
+    }
+
 
     /*
      * 유저(userId)가 현재 참여한 방이 있는지 확인
@@ -144,6 +167,5 @@ public class RoomService {
     private Team generateTeam(Integer userCount) {
         return (userCount%2 == 0) ? Team.RED : Team.BLUE;
     }
-
 
 }

--- a/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
+++ b/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
@@ -15,8 +15,12 @@ import org.prography.pingpong.domain.user.repository.UserRepository;
 import org.prography.pingpong.global.exception.ApiException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
 
 @Service
 @Transactional(readOnly = true)
@@ -26,6 +30,8 @@ public class RoomService {
     private final RoomRepository roomRepository;
     private final UserRoomRepository userRoomRepository;
     private final UserRepository userRepository;
+
+    private final ThreadPoolTaskScheduler taskScheduler;
 
 
     @Transactional
@@ -149,9 +155,9 @@ public class RoomService {
         // 방의 상태를 진행중(PROGRESS) 상태로 변경
         room.changeStatus(RoomStatus.PROGRESS);
 
+        // 게임시작이 된 방은 1분 뒤 종료(FINISH) 상태로 변경
+        scheduleRoomStatusChanged(room, RoomStatus.FINISH);
 
-
-        // 대기(WAIT) 상태인 방만 ��임을 시작 가능
     }
 
 
@@ -168,4 +174,11 @@ public class RoomService {
         return (userCount%2 == 0) ? Team.RED : Team.BLUE;
     }
 
+    @Async
+    private void scheduleRoomStatusChanged(Room room, RoomStatus roomStatus) {
+        taskScheduler.schedule(() -> {
+            room.changeStatus(roomStatus);
+            roomRepository.save(room);
+        }, Instant.now().plusSeconds(60));
+    }
 }

--- a/src/main/java/org/prography/pingpong/global/config/SchedulerConfig.java
+++ b/src/main/java/org/prography/pingpong/global/config/SchedulerConfig.java
@@ -1,0 +1,18 @@
+package org.prography.pingpong.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(100);
+        scheduler.initialize();
+        return scheduler;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: update # TODO change create
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
# ✏️ Description
### 게임시작 API

- 호스트인 유저만 게임을 시작할 수 있습니다. 만약 호스트가 아니라면 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)
- 방 정원이 방의 타입에 맞게 모두 꽉 찬 상태에서만 게임을 시작할 수 있습니다. 만약 그렇지 않다면 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)
- 현재 방의 상태가 대기(WAIT) 상태일 때만 시작할 수 있습니다. 만약 그렇지 않다면 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)
- 방의 상태를 진행중(PROGRESS) 상태로 변경합니다.
- 게임시작이 된 방은 1분 뒤 종료(FINISH) 상태로 변경됩니다.
- 존재하지 않는 id에 대한 요청이라면 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)

> API 명세

```
PUT /room/start/{roomId}
body
{
   "userId" : int
}
```

> Response

```json
{
  "code" : 200,
  "message" : "API 요청이 성공했습니다."
}
```

## ThreadPoolTaskScheduler

API 요청을 받은 후 60초 후에 비동기 처리를 진행하기 위해 `ThreadPoolTaskScheduler`를 사용

### SchedulerConfig
```java
@Configuration
public class SchedulerConfig {

    @Bean
    public ThreadPoolTaskScheduler taskScheduler() {
        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
        scheduler.setPoolSize(100);
        scheduler.initialize();
        return scheduler;
    }

}
```

### RoomService
```java
    @Async
    private void scheduleRoomStatusChanged(Room room, RoomStatus roomStatus) {
        taskScheduler.schedule(() -> {
            room.changeStatus(roomStatus);
            roomRepository.save(room);
        }, Instant.now().plusSeconds(60));
    }
```