### PR TITLE
[FEAT] 팀 변경 API 

### DIFF
--- a/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
+++ b/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
@@ -59,8 +59,8 @@ public class RoomController {
     @PutMapping("/team/{roomId}")
     public ApiResponse changeTeam(@PathVariable("roomId") int roomId,
                                   @RequestBody @Validated TeamChangeReqDto teamChangeReqDto) {
-        UserRoomDto userRoomDto = roomService.changeTeam(roomId, teamChangeReqDto);
-        return ApiResponse.success(userRoomDto);
+        roomService.changeTeam(roomId, teamChangeReqDto);
+        return ApiResponse.success();
     }
 
 }

--- a/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
+++ b/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
@@ -2,11 +2,14 @@ package org.prography.pingpong.domain.room.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.prography.pingpong.domain.room.dto.*;
+import org.prography.pingpong.domain.room.entity.UserRoom;
 import org.prography.pingpong.domain.room.service.RoomService;
 import org.prography.pingpong.global.common.response.ApiResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -54,9 +57,10 @@ public class RoomController {
     }
 
     @PutMapping("/team/{roomId}")
-    public ApiResponse teamChange(@PathVariable("roomId") int roomId,
+    public ApiResponse changeTeam(@PathVariable("roomId") int roomId,
                                   @RequestBody @Validated TeamChangeReqDto teamChangeReqDto) {
-        return ApiResponse.success();
+        List<UserRoomDto> userRoomList = roomService.changeTeam(roomId, teamChangeReqDto);
+        return ApiResponse.success(userRoomList);
     }
 
 }

--- a/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
+++ b/src/main/java/org/prography/pingpong/domain/room/controller/RoomController.java
@@ -59,8 +59,8 @@ public class RoomController {
     @PutMapping("/team/{roomId}")
     public ApiResponse changeTeam(@PathVariable("roomId") int roomId,
                                   @RequestBody @Validated TeamChangeReqDto teamChangeReqDto) {
-        List<UserRoomDto> userRoomList = roomService.changeTeam(roomId, teamChangeReqDto);
-        return ApiResponse.success(userRoomList);
+        UserRoomDto userRoomDto = roomService.changeTeam(roomId, teamChangeReqDto);
+        return ApiResponse.success(userRoomDto);
     }
 
 }

--- a/src/main/java/org/prography/pingpong/domain/room/dto/UserRoomDto.java
+++ b/src/main/java/org/prography/pingpong/domain/room/dto/UserRoomDto.java
@@ -1,0 +1,12 @@
+package org.prography.pingpong.domain.room.dto;
+
+import org.prography.pingpong.domain.room.entity.UserRoom;
+import org.prography.pingpong.domain.room.entity.enums.Team;
+
+public record UserRoomDto(Integer id, Integer roomId, Integer userId, Team team) {
+
+    public static UserRoomDto create(UserRoom userRoom) {
+        return new UserRoomDto(userRoom.getId(), userRoom.getRoom().getId(), userRoom.getUser().getId(), userRoom.getTeam());
+    }
+
+}

--- a/src/main/java/org/prography/pingpong/domain/room/entity/Room.java
+++ b/src/main/java/org/prography/pingpong/domain/room/entity/Room.java
@@ -23,7 +23,7 @@ public class Room {
 
     private String title;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "userId")
     private User host;
 

--- a/src/main/java/org/prography/pingpong/domain/room/entity/UserRoom.java
+++ b/src/main/java/org/prography/pingpong/domain/room/entity/UserRoom.java
@@ -13,11 +13,11 @@ public class UserRoom {
     @Column(name="userRoomId")
     private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "roomId")
     private Room room;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "userId")
     private User user;
 
@@ -35,6 +35,10 @@ public class UserRoom {
 
     public static UserRoom create(Room room, User user, Team team) {
         return new UserRoom(room, user, team);
+    }
+
+    public void changeTeam() {
+        this.team = this.team.equals(Team.RED)? Team.BLUE : Team.RED;
     }
 
     public Integer getId() {

--- a/src/main/java/org/prography/pingpong/domain/room/entity/enums/RoomType.java
+++ b/src/main/java/org/prography/pingpong/domain/room/entity/enums/RoomType.java
@@ -4,12 +4,14 @@ import lombok.Getter;
 
 @Getter
 public enum RoomType {
-    SINGLE("단식"),
-    DOUBLE("복식");
+    SINGLE("단식", 2),
+    DOUBLE("복식", 4);
 
     private final String description;
+    private final Integer value;
 
-    RoomType(String description) {
+    RoomType(String description, Integer value) {
         this.description = description;
+        this.value = value;
     }
 }

--- a/src/main/java/org/prography/pingpong/domain/room/repository/UserRoomRepository.java
+++ b/src/main/java/org/prography/pingpong/domain/room/repository/UserRoomRepository.java
@@ -1,10 +1,12 @@
 package org.prography.pingpong.domain.room.repository;
 
 import org.prography.pingpong.domain.room.entity.UserRoom;
+import org.prography.pingpong.domain.room.entity.enums.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserRoomRepository extends JpaRepository<UserRoom, Integer> {
@@ -20,4 +22,7 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Integer> {
     void deleteByUserId(Integer userId);
 
     List<UserRoom> findByRoomId(Integer userId);
+
+    Optional<UserRoom> findByUserId(Integer userId);
+
 }

--- a/src/main/java/org/prography/pingpong/domain/room/repository/UserRoomRepository.java
+++ b/src/main/java/org/prography/pingpong/domain/room/repository/UserRoomRepository.java
@@ -4,6 +4,8 @@ import org.prography.pingpong.domain.room.entity.UserRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserRoomRepository extends JpaRepository<UserRoom, Integer> {
 
@@ -17,4 +19,5 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Integer> {
 
     void deleteByUserId(Integer userId);
 
+    List<UserRoom> findByRoomId(Integer userId);
 }

--- a/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
+++ b/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
@@ -166,7 +166,7 @@ public class RoomService {
     }
 
     @Transactional
-    public UserRoomDto changeTeam(int roomId, TeamChangeReqDto teamChangeReqDto) {
+    public void changeTeam(int roomId, TeamChangeReqDto teamChangeReqDto) {
 
         // 유저(userId)가 현재 해당 방(roomId)에 참가한 상태에서만 팀 변경이 가능
         if(!isJoinRoom(teamChangeReqDto.userId()))
@@ -203,8 +203,6 @@ public class RoomService {
 
         // 유저(userId)가 현재 속한 팀 기준 반대 팀으로 변경
         userRoom.changeTeam();
-
-        return UserRoomDto.create(userRoom);
 
     }
 

--- a/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
+++ b/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
@@ -44,21 +44,25 @@ public class RoomService {
     @Transactional
     public void createRoom(RoomCreateReqDto roomCreateReqDto) {
 
-        //방을 생성하려고 하는 user(userId)의 상태가 활성(ACTIVE)상태일 때만, 방을 생성
+        // 방을 생성하려고 하는 user(userId)의 상태가 활성(ACTIVE)상태일 때만, 방을 생성
         Integer userId = roomCreateReqDto.userId();
-        User findUser = userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApiException("RoomService.createRoom"));
 
-        if(!findUser.getStatus().equals(UserStatus.ACTIVE))
+        if(!user.getStatus().equals(UserStatus.ACTIVE))
             throw new ApiException("RoomService.createRoom");
 
-        //방을 생성하려고 하는 user(userId)가 현재 참여한 방이 있다면, 방생성 X
+        // 방을 생성하려고 하는 user(userId)가 현재 참여한 방이 있다면, 방생성 X
         if(isJoinRoom(userId))
             throw new ApiException("RoomService.createRoom");
 
-         //방은 초기에 대기(WAIT) 상태로 생성
-        Room room = roomCreateReqDto.create(findUser);
+        // 방은 초기에 대기(WAIT) 상태로 생성
+        Room room = roomCreateReqDto.create(user);
         roomRepository.save(room);
+
+        // userRoom 생성
+        UserRoom userRoom = UserRoom.create(room, user, Team.RED);
+        userRoomRepository.save(userRoom);
 
     }
 
@@ -95,16 +99,15 @@ public class RoomService {
 
         // 참가하고자 하는 방(roomId)의 정원이 미달일 때만, 참가가 가능
         int userCount = userRoomRepository.countByRoomId(roomId);
-        System.out.println("userCount : " + userCount);
 
-        if(room.getType().equals(RoomType.SINGLE) && userCount >= 1)
+        if(room.getType().equals(RoomType.SINGLE) && userCount >= 2)
             throw new ApiException("RoomService.attendRoom");
 
-        if(room.getType().equals(RoomType.DOUBLE) && userCount >= 3)
+        if(room.getType().equals(RoomType.DOUBLE) && userCount >= 4)
             throw new ApiException("RoomService.attendRoom");
 
         // userRoom 생성
-        UserRoom userRoom = UserRoom.create(room, user, generateTeam(userCount));
+        UserRoom userRoom = UserRoom.create(room, user, generateTeam(roomId));
         userRoomRepository.save(userRoom);
 
     }
@@ -163,7 +166,7 @@ public class RoomService {
     }
 
     @Transactional
-    public List<UserRoomDto> changeTeam(int roomId, TeamChangeReqDto teamChangeReqDto) {
+    public UserRoomDto changeTeam(int roomId, TeamChangeReqDto teamChangeReqDto) {
 
         // 유저(userId)가 현재 해당 방(roomId)에 참가한 상태에서만 팀 변경이 가능
         if(!isJoinRoom(teamChangeReqDto.userId()))
@@ -172,12 +175,36 @@ public class RoomService {
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(() -> new ApiException("RoomService.changeTeam"));
 
+        UserRoom userRoom = userRoomRepository.findByUserId(teamChangeReqDto.userId())
+                .orElseThrow(() -> new ApiException("RoomService.changeTeam"));
+
         List<UserRoomDto> userRoomList = userRoomRepository.findByRoomId(roomId)
                 .stream()
                 .map(UserRoomDto::create)
                 .collect(Collectors.toList());
 
-        return userRoomList;
+        // 변경되려는 팀의 인원이 이미 해당 방 정원의 절반과 같다면 팀이 변경되지 않고 201 응답을 반환
+        if(userRoom.getTeam().equals(Team.RED)) {
+            Long blueCount = userRoomList.stream().filter(ur -> ur.team() == Team.BLUE).count();
+            if(blueCount >= room.getType().getValue()/2)
+                throw new ApiException("RoomService.changeTeam");
+        }
+
+        // 변경되려는 팀의 인원이 이미 해당 방 정원의 절반과 같다면 팀이 변경되지 않고 201 응답을 반환
+        else if(userRoom.getTeam().equals(Team.BLUE)) {
+            Long redCount = userRoomList.stream().filter(ur -> ur.team() == Team.RED).count();
+            if(redCount >= room.getType().getValue()/2)
+                throw new ApiException("RoomService.changeTeam");
+        }
+
+        // 현재 방의 상태가 대기(WAIT) 상태일 때만 팀을 변경할 수 있습니다. 만약 그렇지 않다면 201 응답을 반환
+        if(!room.getStatus().equals(RoomStatus.WAIT))
+            throw new ApiException("RoomService.changeTeam");
+
+        // 유저(userId)가 현재 속한 팀 기준 반대 팀으로 변경
+        userRoom.changeTeam();
+
+        return UserRoomDto.create(userRoom);
 
     }
 
@@ -191,8 +218,16 @@ public class RoomService {
         return false;
     }
 
-    private Team generateTeam(Integer userCount) {
-        return (userCount%2 == 0) ? Team.RED : Team.BLUE;
+    private Team generateTeam(Integer roomId) {
+        List<UserRoomDto> userRoomList = userRoomRepository.findByRoomId(roomId)
+                .stream()
+                .map(UserRoomDto::create)
+                .collect(Collectors.toList());
+
+        Long redCount = userRoomList.stream().filter(ur -> ur.team() == Team.RED).count();
+        Long blueCount = userRoomList.stream().filter(ur -> ur.team() == Team.BLUE).count();
+
+        return redCount > blueCount ? Team.BLUE : Team.RED;
     }
 
     @Async

--- a/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
+++ b/src/main/java/org/prography/pingpong/domain/room/service/RoomService.java
@@ -21,6 +21,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -160,6 +162,25 @@ public class RoomService {
 
     }
 
+    @Transactional
+    public List<UserRoomDto> changeTeam(int roomId, TeamChangeReqDto teamChangeReqDto) {
+
+        // 유저(userId)가 현재 해당 방(roomId)에 참가한 상태에서만 팀 변경이 가능
+        if(!isJoinRoom(teamChangeReqDto.userId()))
+            throw new ApiException("RoomService.changeTeam");
+
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new ApiException("RoomService.changeTeam"));
+
+        List<UserRoomDto> userRoomList = userRoomRepository.findByRoomId(roomId)
+                .stream()
+                .map(UserRoomDto::create)
+                .collect(Collectors.toList());
+
+        return userRoomList;
+
+    }
+
 
     /*
      * 유저(userId)가 현재 참여한 방이 있는지 확인
@@ -181,4 +202,5 @@ public class RoomService {
             roomRepository.save(room);
         }, Instant.now().plusSeconds(60));
     }
+
 }


### PR DESCRIPTION
# ✏️ Description
### 팀 변경 API

- 유저(userId)가 현재 해당 방(roomId)에 참가한 상태에서만 팀 변경이 가능합니다. 만약 그렇지 않다면 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)
- 유저(userId)가 현재 속한 팀 기준 반대 팀으로 변경됩니다. (RED -> BLUE / BLUE -> RED)
- 변경되려는 팀의 인원이 이미 해당 방 정원의 절반과 같다면 팀이 변경되지 않고 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)
- 현재 방의 상태가 대기(WAIT) 상태일 때만 팀을 변경할 수 있습니다. 만약 그렇지 않다면 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)
- 존재하지 않는 id에 대한 요청이라면 201 응답을 반환합니다. ([공통 API Response 안내](https://www.notion.so/Spring-197b28e6e3f280f69b43d12da8fc694a?pvs=21) 참고)

> API 명세

```
PUT /team/{roomId}
body
{
   "userId" : int
}
```

> Response

```json
{
  "code" : 200,
  "message" : "API 요청이 성공했습니다."
}
```